### PR TITLE
Geovintage 2024 docs

### DIFF
--- a/src/lehd_changelog.asciidoc
+++ b/src/lehd_changelog.asciidoc
@@ -15,6 +15,11 @@ Feedback is welcome.
 Please write us at link:mailto:ces.qwi.feedback@census.gov?subject=LEHD_Schema[ces.qwi.feedback@census.gov].
 ==============================================
 
+== V4.12.0
+
+- Updated to 2024 geography - affects shapefiles, label files unchanged from 2023
+- Changed earnings year to 2021 dollars
+
 == V4.11.2
 
 - Updated select institution names

--- a/src/lehd_public_use_schema.asciidoc
+++ b/src/lehd_public_use_schema.asciidoc
@@ -502,7 +502,7 @@ include::label_inst_level.csv[]
 ( link:label_institution.csv[] )
 
 Institution identifiers are sourced from the
-https://www2.ed.gov/offices/OSFAP/PEPS/dataextracts.html[U.S. Department of Education, Federal Student Aid office].
+https://fsapartners.ed.gov/additional-resources/reports/weekly-school-file[U.S. Department of Education, Federal Student Aid office].
 This list has been supplemented with records for regional groupings of institutions (may be used in future PSEO tabulations).
 
 [%autowidth%header,format=csv,cols="^1,<4,^2,3*^1",separator=,]

--- a/src/lehd_public_use_schema.asciidoc
+++ b/src/lehd_public_use_schema.asciidoc
@@ -571,7 +571,7 @@ When tabulating across all cohorts, the value *0000* will be used for grad_cohor
 ( link:label_geo_level.csv[] )
 
 Geography labels for data files are provided in separate files, by scope.Each file 'label_geography_SCOPE.csv' may contain one or more types of records as flagged by <<Geographic Levels,geo_level>>. For convenience, a composite file containing all geocodes is available as link:label_geography.csv[].
-The 2023 vintage of https://www.census.gov/geographies/mapping-files/time-series/geo/tiger-line-file.html[Census TIGER/Line geography] is used for all tabulations as of the R2024Q1 release.
+The 2024 vintage of https://www.census.gov/geographies/mapping-files/time-series/geo/tiger-line-file.html[Census TIGER/Line geography] is used for all tabulations as of the R2025Q1 release.
 
 Shapefiles are described in a link:lehd_shapefiles{ext-relative}[separate document].
 

--- a/src/lehd_shapefiles.asciidoc
+++ b/src/lehd_shapefiles.asciidoc
@@ -28,13 +28,13 @@ New TIGER/Line shapefiles are typically released by the Census Bureau's Geograph
 
 == Sources
 
-Files are derived from https://www.census.gov/geographies/mapping-files/time-series/geo/tiger-line-file.2023.html[TIGER/Line 2023 shapefiles]:
+Files are derived from https://www.census.gov/geographies/mapping-files/time-series/geo/tiger-line-file.2024.html[TIGER/Line 2024 shapefiles]:
 
-* https://www2.census.gov/geo/tiger/TIGER2023/STATE/[tl_2023_us_state]
-* https://www2.census.gov/geo/tiger/TIGER2023/COUNTY/[tl_2023_us_county]
-* https://www2.census.gov/geo/tiger/TIGER2023/CBSA/[tl_2023_us_cbsa]
-* https://www2.census.gov/geo/tiger/TIGER2023/PLACE/[tl_2023_(ST)_place]  (for creation of WIA/WIB shapefile)
-* https://www2.census.gov/geo/tiger/TIGER2023/COUSUB/[tl_2023_(ST)_cousub] (for creation of WIA/WIB shapefile)
+* https://www2.census.gov/geo/tiger/TIGER2024/STATE/[tl_2024_us_state]
+* https://www2.census.gov/geo/tiger/TIGER2024/COUNTY/[tl_2024_us_county]
+* https://www2.census.gov/geo/tiger/TIGER2024/CBSA/[tl_2024_us_cbsa]
+* https://www2.census.gov/geo/tiger/TIGER2024/PLACE/[tl_2024_(ST)_place]  (for creation of WIA/WIB shapefile)
+* https://www2.census.gov/geo/tiger/TIGER2024/COUSUB/[tl_2024_(ST)_cousub] (for creation of WIA/WIB shapefile)
 
 == Transformations
 


### PR DESCRIPTION
- Doc changes for the 2024 geovintage upgrade
- Confirmed that no label files updated between the 2023 and 2024 geovintage
- Shapefiles will update but those are not contained here
- update one broken link from the auto check (use the redirected location)